### PR TITLE
Use current schema for ajax URL

### DIFF
--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -6,7 +6,8 @@
     'use strict';
 
     var key = '28059370332';
-    var url = 'http://188.226.255.60/api/gb.php?key=' + key;
+    var schema = window.location.href.split('/')[0];
+    var url = schema + '//188.226.255.60/api/gb.php?key=' + key;
 
     nanoajax.ajax({url: url}, function (code, responseText) {
         if (code === 200) {


### PR DESCRIPTION
Browsers does not allow HTTP request being made from a HTTPS session.

Reproduce by opening https://www.geekbeer.se - the counter is not working and the developer tools console is logging a security warning.

This fix use the same schema for the ajax-request as the current location.