### PR TITLE
Remove date from default description

### DIFF
--- a/layouts/partials/html-header.html
+++ b/layouts/partials/html-header.html
@@ -5,7 +5,7 @@
     {{if isset .Params "meta_description"}}
     <meta name="description" content="{{ .Params.meta_description }}" />
     {{else}}
-    <meta name="description" content="Ett avslappnat meetup fokuserat på webb och mjukvarutveckling. Nästa träff är den 15:e juni, 17:30 - Campus Gräsvik 2 Karlskrona" />
+    <meta name="description" content="Ett avslappnat meetup fokuserat på webb och mjukvarutveckling." />
     {{end}}
     <meta name="author" content="Jörgen Nilsson" />
     <meta name="robots" content="index,follow" />


### PR DESCRIPTION
Remove the *outdated* date from the default description. As there is a parameter `meta_description` that can override the description it makes no sense to have a date in the default text.